### PR TITLE
Do everything over https, not http

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules
 var/log/
-key.pem
-cert.pem
+keys

--- a/app.js
+++ b/app.js
@@ -218,7 +218,3 @@ https.createServer({ key: fs.readFileSync('./keys/key.pem'),
       .listen(port, function () {
           log.info('express port listening at localhost:' + port);
       });
-
-app.listen(port, function () {
-    log.info('express port listening at localhost:' + port);
-});

--- a/app.js
+++ b/app.js
@@ -213,8 +213,8 @@ app.get('/api/v1/donor/find/:selector', function(req, res) {
         });
 });
 
-https.createServer({ key: fs.readFileSync('./keys/key.pem'),
-                     cert: fs.readFileSync('./keys/cert.pem')}, app)
+https.createServer({ key: fs.readFileSync(nconf.get('keys:key')),
+                     cert: fs.readFileSync(nconf.get('keys:cert'))}, app)
       .listen(port, function () {
           log.info('express port listening at localhost:' + port);
       });

--- a/app.js
+++ b/app.js
@@ -1,14 +1,12 @@
 var express = require('express');
+var fs = require('fs');
+var https = require('https');
 var path = require('path');
 var bodyParser = require('body-parser');
 var mongo = require('./data/mongo.js');
 var bunyan = require('bunyan');
 var nconf = require('nconf');
 var jwt = require('jsonwebtoken');
-
-var app = express();
-
-var port = nconf.get('app:port');
 
 var log = bunyan.createLogger({
     name: 'app',
@@ -34,6 +32,10 @@ var log = bunyan.createLogger({
         }
     ]
 });
+
+var app = express();
+
+var port = nconf.get('app:port');
 
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json());
@@ -210,6 +212,12 @@ app.get('/api/v1/donor/find/:selector', function(req, res) {
             res.send(doc);
         });
 });
+
+https.createServer({ key: fs.readFileSync('./keys/key.pem'),
+                     cert: fs.readFileSync('./keys/cert.pem')}, app)
+      .listen(port, function () {
+          log.info('express port listening at localhost:' + port);
+      });
 
 app.listen(port, function () {
     log.info('express port listening at localhost:' + port);

--- a/config.json
+++ b/config.json
@@ -17,5 +17,9 @@
     },
     "auth": {
         "secret": "x"
+    },
+    "keys": {
+        "key": "./keys/key.pem",
+        "cert": "./keys/cert.pem"
     }
 }


### PR DESCRIPTION
big change here - now everything is more secure.

you'll need the cert.pem and key.pem into a folder called `keys/` at the root of your directory. don't worry about accidentally commiting these, I added them to the .gitignore

just put those two files in the google drive into a `keys/` folder and run `node app.js`.  and from now on instead of going to `localhost:3000` you'll go to `https://localhost:3000`

once both of you @compassface and @jacobbuettner can do this let's merge
