### PR TITLE
if no child picture api callsback

### DIFF
--- a/data/mongo.js
+++ b/data/mongo.js
@@ -379,13 +379,17 @@ exports.getPic = function(id, collection, callback) {
                     var imageId = new mongo.ObjectID(doc.image_id);
                     var gridStore = new mongo.GridStore(db, imageId, 'r');
                     gridStore.open(function(err, gridStore) {
-                        gridStore.seek(0, function() {
-                            gridStore.read(function(err, data) {
-                                db.close();
-                                log.trace('got picture for child with id '+ id);
-                                callback(data.toString('base64'));
+                        if (typeof gridStore !== 'undefined') {
+                            gridStore.seek(0, function() {
+                                gridStore.read(function(err, data) {
+                                    db.close();
+                                    log.trace('got picture for child with id '+ id);
+                                    callback(data.toString('base64'));
+                                });
                             });
-                        });
+                        } else {
+                            callback({'err': 'picture not found.'});
+                        }
                     });
                 }
             });

--- a/public/js/account.js
+++ b/public/js/account.js
@@ -542,7 +542,7 @@ $(document).ready(function() {
                                         if (res.success === true) {
                                             alert('your request for the removal of your sponsorship has been submitted. you will receive an email when the process has been completed.');
                                             button.disabled = true;
-                                            button.title = "Your request has been received, please wait for it to be processed by an AMG admin";
+                                            button.title = 'Your request has been received, please wait for it to be processed by an AMG admin';
                                         }
                                     },
                                     error: function() {


### PR DESCRIPTION
fixes #151 

when image_id exists but that doc in fs.files has been deleted, api returns:
`{"success":false,"message":"picture not found."}`

example:
[https://localhost:3000/api/v1/children/id/56ccd075f6c292b46f2007ba](https://localhost:3000/api/v1/children/id/56ccd075f6c292b46f2007ba)
returns a child but the below call but
[https://localhost:3000/api/v1/pictures/id/56ccd075f6c292b46f2007ba](https://localhost:3000/api/v1/pictures/id/56ccd075f6c292b46f2007ba)
returns the correct "picture not found" error
